### PR TITLE
Issue #31 - Updated EFCachePolicyParser to handle additional tag comments

### DIFF
--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests/EFCachePolicyParserTests.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests/EFCachePolicyParserTests.cs
@@ -26,6 +26,29 @@ namespace EFCoreSecondLevelCacheInterceptor.Tests
         }
 
         [TestMethod]
+        public void TestGetEFCachePolicyWithAdditionalTagComments()
+        {
+            const string commandText =
+@"-- CustomTagAbove
+
+-- EFCachePolicy[Index(27)] --> Absolute|00:45:00
+
+-- CustomTagBelow
+
+SELECT TOP(1) [p].[Id], [p].[Title], [p].[UserId], [p].[post_type], [u].[Id], [u].[Name], [u].[UserStatus]
+FROM [Posts] AS [p]
+INNER JOIN [Users] AS [u] ON [p].[UserId] = [u].[Id]
+WHERE [p].[post_type] IN (N'post_base', N'post_page') AND ([p].[Id] > @__param1_0)
+ORDER BY [p].[Id]";
+
+            var cachePolicyParser = EFServiceProvider.GetRequiredService<IEFCachePolicyParser>();
+            var cachePolicy = cachePolicyParser.GetEFCachePolicy(commandText);
+
+            Assert.AreEqual(expected: CacheExpirationMode.Absolute, actual: cachePolicy.CacheExpirationMode);
+            Assert.AreEqual(expected: TimeSpan.FromMinutes(45), actual: cachePolicy.CacheTimeout);
+        }
+
+        [TestMethod]
         public void TestGetEFCachePolicyWithAllParts()
         {
             string commandText = EFCachePolicy.Configure(options =>
@@ -43,6 +66,40 @@ namespace EFCoreSecondLevelCacheInterceptor.Tests
             Assert.AreEqual(expected: TimeSpan.FromMinutes(45), actual: cachePolicy.CacheTimeout);
             Assert.AreEqual(expected: "saltKey", actual: cachePolicy.CacheSaltKey);
             CollectionAssert.AreEqual(expected: new SortedSet<string> { "item 1", "item 2" }, actual: cachePolicy.CacheItemsDependencies as SortedSet<string>);
+        }
+
+        [TestMethod]
+        public void TestRemoveEFCachePolicyTagWithAdditionalTagComments()
+        {
+            const string commandText =
+@"-- CustomTagAbove
+
+-- EFCachePolicy[Index(27)] --> Absolute|00:45:00
+
+-- CustomTagBelow
+
+SELECT TOP(1) [p].[Id], [p].[Title], [p].[UserId], [p].[post_type], [u].[Id], [u].[Name], [u].[UserStatus]
+FROM [Posts] AS [p]
+INNER JOIN [Users] AS [u] ON [p].[UserId] = [u].[Id]
+WHERE [p].[post_type] IN (N'post_base', N'post_page') AND ([p].[Id] > @__param1_0)
+ORDER BY [p].[Id]";
+
+            var cachePolicyParser = EFServiceProvider.GetRequiredService<IEFCachePolicyParser>();
+            var commandTextWithCachePolicyTagRemoved = cachePolicyParser.RemoveEFCachePolicyTag(commandText);
+
+            var expectedResult =
+@"-- CustomTagAbove
+
+
+-- CustomTagBelow
+
+SELECT TOP(1) [p].[Id], [p].[Title], [p].[UserId], [p].[post_type], [u].[Id], [u].[Name], [u].[UserStatus]
+FROM [Posts] AS [p]
+INNER JOIN [Users] AS [u] ON [p].[UserId] = [u].[Id]
+WHERE [p].[post_type] IN (N'post_base', N'post_page') AND ([p].[Id] > @__param1_0)
+ORDER BY [p].[Id]";
+
+            Assert.AreEqual(expected: expectedResult, actual: commandTextWithCachePolicyTagRemoved);
         }
     }
 }


### PR DESCRIPTION
* Updated EFCachePolicyParser.getParsedPolicy(..) to find the line starting with the cache policy tag prefix string in lieu of always assuming it will be on the first line.
* Updated EFCachePolicyParser.RemoveEFCachePolicyTag(..) so that it doesn't throw an out of range exception if the cache policy tag comment is not on the first line.
* Added test cases to cover additional comments/tag calls.