### PR TITLE
Issue #33 - Support for a RemoveCachePolicyTagBeforeExecution Setting

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor/EFCachePolicyParser.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/EFCachePolicyParser.cs
@@ -77,6 +77,14 @@ namespace EFCoreSecondLevelCacheInterceptor
                 return commandText;
             }
 
+            var additionalNewlineIndex = commandText.IndexOf('\n', endIndex + 1) - endIndex;
+            if (additionalNewlineIndex == 1 || additionalNewlineIndex == 2)
+            {
+                // EF's TagWith(..) method inserts an additional line break between
+                // comments which we can remove as well
+                endIndex += additionalNewlineIndex;
+            }
+
             return commandText.Remove(startIndex, (endIndex - startIndex) + 1);
         }
 

--- a/src/EFCoreSecondLevelCacheInterceptor/EFServiceCollectionExtensions.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/EFServiceCollectionExtensions.cs
@@ -50,6 +50,11 @@ namespace EFCoreSecondLevelCacheInterceptor
         /// Should the debug level loggig be disabled?
         /// </summary>
         public bool DisableLogging { set; get; }
+
+        /// <summary>
+        /// Should the cache policy tag comment be removed from the command text?
+        /// </summary>
+        public bool RemoveCachePolicyTagBeforeExecution { get; set; }
     }
 
     /// <summary>
@@ -197,6 +202,16 @@ namespace EFCoreSecondLevelCacheInterceptor
         public EFCoreSecondLevelCacheOptions DisableLogging(bool value = false)
         {
             Settings.DisableLogging = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Should the cache policy tag comment be removed from the command text?
+        /// Set it to true for improved performance in query plan cache scenarios.
+        /// </summary>
+        public EFCoreSecondLevelCacheOptions RemoveCachePolicyTagBeforeExecution(bool value)
+        {
+            Settings.RemoveCachePolicyTagBeforeExecution = value;
             return this;
         }
     }

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/MsSqlServiceCollectionExtensions.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/MsSqlServiceCollectionExtensions.cs
@@ -6,20 +6,28 @@ namespace EFCoreSecondLevelCacheInterceptor.Tests.DataLayer
 {
     public static class MsSqlServiceCollectionExtensions
     {
-        public static IServiceCollection AddConfiguredMsSqlDbContext(this IServiceCollection services, string connectionString)
+        public static IServiceCollection AddConfiguredMsSqlDbContext(
+            this IServiceCollection services,
+            string connectionString, 
+            Action<DbContextOptionsBuilder> configureDbContextOptions = null)
         {
             services.AddDbContextPool<ApplicationDbContext>((serviceProvider, optionsBuilder) =>
-                    optionsBuilder
-                        .UseSqlServer(
-                            connectionString,
-                            sqlServerOptionsBuilder =>
-                            {
-                                sqlServerOptionsBuilder
-                                    .CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds)
-                                    .EnableRetryOnFailure()
-                                    .MigrationsAssembly(typeof(MsSqlServiceCollectionExtensions).Assembly.FullName);
-                            })
-                        .AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>()));
+            {
+                optionsBuilder
+                    .UseSqlServer(
+                        connectionString,
+                        sqlServerOptionsBuilder =>
+                        {
+                            sqlServerOptionsBuilder
+                                .CommandTimeout((int)TimeSpan.FromMinutes(3).TotalSeconds)
+                                .EnableRetryOnFailure()
+                                .MigrationsAssembly(typeof(MsSqlServiceCollectionExtensions).Assembly.FullName);
+                        })
+                    .AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>());
+
+                configureDbContextOptions?.Invoke(optionsBuilder);
+            });
+
             return services;
         }
     }

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests/SecondLevelCacheInterceptorRemoveCachePolicyCommentTests.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests/SecondLevelCacheInterceptorRemoveCachePolicyCommentTests.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EFCoreSecondLevelCacheInterceptor.Tests
+{
+    [TestClass]
+    public class SecondLevelCacheInterceptorRemoveCachePolicyCommentTests
+    {
+        [DataTestMethod]
+        [DataRow(TestCacheProvider.BuiltInInMemory)]
+        [DataRow(TestCacheProvider.CacheManagerCoreInMemory)]
+        [DataRow(TestCacheProvider.CacheManagerCoreRedis)]
+        [DataRow(TestCacheProvider.EasyCachingCoreInMemory)]
+        [DataRow(TestCacheProvider.EasyCachingCoreRedis)]
+        public void SecondLevelCache_with_remove_comment_option_enabled_doesnt_hit_the_database(TestCacheProvider cacheProvider)
+        {
+
+            Action<EFCoreSecondLevelCacheOptions> configureCacheOptions = (options) => options.RemoveCachePolicyTagBeforeExecution(true);
+
+            var testDbCommandInterceptor = new TestDbCommandInterceptor();
+            Action<DbContextOptionsBuilder> configureDbContextOptions = (optionsBuilder) => optionsBuilder.AddInterceptors(testDbCommandInterceptor);
+
+            EFServiceProvider.RunInContext(cacheProvider, LogLevel.Debug, false, null, configureCacheOptions, configureDbContextOptions, (context, loggerProvider) =>
+            {
+                var isActive = true;
+                var productName = "Product2";
+
+                var list1 = context.Products
+                    .TagWith("Custom Tag")
+                    .OrderBy(product => product.ProductNumber)
+                    .Where(product => product.IsActive == isActive && product.ProductName == productName)
+                    .Cacheable(CacheExpirationMode.Absolute, TimeSpan.FromMinutes(45))
+                    .ToList();
+
+                Assert.IsTrue(list1.Any());
+                Assert.AreEqual(0, loggerProvider.GetCacheHitCount());
+
+                var actualSqlExecuted1 = testDbCommandInterceptor.ExecutedCommandText[0];
+                var expectedSql1 =
+@"-- Custom Tag
+
+SELECT [p].[ProductId], [p].[IsActive], [p].[Notes], [p].[ProductName], [p].[ProductNumber], [p].[UserId]
+FROM [Products] AS [p]
+WHERE ([p].[IsActive] = @__isActive_0) AND ([p].[ProductName] = @__productName_1)
+ORDER BY [p].[ProductNumber]";
+
+                Assert.AreEqual(actualSqlExecuted1, expectedSql1);
+
+                var list2 = context.Products
+                    .TagWith("Custom Tag")
+                    .OrderBy(product => product.ProductNumber)
+                    .Where(product => product.IsActive == isActive && product.ProductName == productName)
+                    .Cacheable(CacheExpirationMode.Absolute, TimeSpan.FromMinutes(45))
+                    .ToList();
+
+                Assert.IsTrue(list2.Any());
+                Assert.AreEqual(1, loggerProvider.GetCacheHitCount());
+
+                var actualSqlExecuted2 = testDbCommandInterceptor.ExecutedCommandText[1];
+                var expectedSql2 =
+@"-- Custom Tag
+
+SELECT [p].[ProductId], [p].[IsActive], [p].[Notes], [p].[ProductName], [p].[ProductNumber], [p].[UserId]
+FROM [Products] AS [p]
+WHERE ([p].[IsActive] = @__isActive_0) AND ([p].[ProductName] = @__productName_1)
+ORDER BY [p].[ProductNumber]";
+
+                Assert.AreEqual(actualSqlExecuted2, expectedSql2);
+            });
+        }
+
+        [DataTestMethod]
+        [DataRow(TestCacheProvider.BuiltInInMemory)]
+        [DataRow(TestCacheProvider.CacheManagerCoreInMemory)]
+        [DataRow(TestCacheProvider.CacheManagerCoreRedis)]
+        [DataRow(TestCacheProvider.EasyCachingCoreInMemory)]
+        [DataRow(TestCacheProvider.EasyCachingCoreRedis)]
+        public async Task SecondLevelCache_with_remove_comment_option_enabled_doesnt_hit_the_database_async(TestCacheProvider cacheProvider)
+        {
+            Action<EFCoreSecondLevelCacheOptions> configureCacheOptions = (options) => options.RemoveCachePolicyTagBeforeExecution(true);
+
+            var testDbCommandInterceptor = new TestDbCommandInterceptor();
+            Action<DbContextOptionsBuilder> configureDbContextOptions = (optionsBuilder) => optionsBuilder.AddInterceptors(testDbCommandInterceptor);
+
+            await EFServiceProvider.RunInContextAsync(cacheProvider, LogLevel.Debug, false, null, configureCacheOptions, configureDbContextOptions, 
+                async (context, loggerProvider) =>
+                {
+                    var isActive = true;
+                    var productName = "Product2";
+
+                    var list1 = await context.Products
+                        .TagWith("Custom Tag")
+                        .OrderBy(product => product.ProductNumber)
+                        .Where(product => product.IsActive == isActive && product.ProductName == productName)
+                        .Cacheable(CacheExpirationMode.Absolute, TimeSpan.FromMinutes(45))
+                        .ToListAsync();
+
+                    Assert.IsTrue(list1.Any());
+                    Assert.AreEqual(0, loggerProvider.GetCacheHitCount());
+
+                    var actualSqlExecuted1 = testDbCommandInterceptor.ExecutedCommandText[0];
+                    var expectedSql1 =
+@"-- Custom Tag
+
+SELECT [p].[ProductId], [p].[IsActive], [p].[Notes], [p].[ProductName], [p].[ProductNumber], [p].[UserId]
+FROM [Products] AS [p]
+WHERE ([p].[IsActive] = @__isActive_0) AND ([p].[ProductName] = @__productName_1)
+ORDER BY [p].[ProductNumber]";
+
+                    Assert.AreEqual(actualSqlExecuted1, expectedSql1);
+
+                    var list2 = await context.Products
+                        .TagWith("Custom Tag")
+                        .OrderBy(product => product.ProductNumber)
+                        .Where(product => product.IsActive == isActive && product.ProductName == productName)
+                        .Cacheable(CacheExpirationMode.Absolute, TimeSpan.FromMinutes(45))
+                        .ToListAsync();
+
+                    Assert.IsTrue(list2.Any());
+                    Assert.AreEqual(1, loggerProvider.GetCacheHitCount());
+
+                    var actualSqlExecuted2 = testDbCommandInterceptor.ExecutedCommandText[1];
+                    var expectedSql2 =
+@"-- Custom Tag
+
+SELECT [p].[ProductId], [p].[IsActive], [p].[Notes], [p].[ProductName], [p].[ProductNumber], [p].[UserId]
+FROM [Products] AS [p]
+WHERE ([p].[IsActive] = @__isActive_0) AND ([p].[ProductName] = @__productName_1)
+ORDER BY [p].[ProductNumber]";
+
+                    Assert.AreEqual(actualSqlExecuted2, expectedSql2);
+                })
+                .ConfigureAwait(false);
+        }
+
+        private class TestDbCommandInterceptor : DbCommandInterceptor
+        {
+            public List<string> ExecutedCommandText { get; } = new List<string>();
+
+            public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result)
+            {
+                ExecutedCommandText.Add(command.CommandText);
+
+                return base.ReaderExecuted(command, eventData, result);
+            }
+
+            public override Task<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default)
+            {
+                ExecutedCommandText.Add(command.CommandText);
+
+                return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Added a new `EFCoreSecondLevelCacheSettings.RemoveCachePolicyTagBeforeExecution` property and options extension method.
* Updated `DbCommandInterceptorProccessor.cs` to check the new setting property. When the setting property is `true` the cache policy comment is removed from the `command.CommandText` before proceeding to execution. A `ConditionalWeakTable` is used to retrieve the parsed cache policy after command execution.
* Added test cases to confirm the cache is still used and the expected sql without the comment is executed when the setting is configured to true.