### PR TITLE
No fixed versions for EF Core references

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor/EFCoreSecondLevelCacheInterceptor.csproj
+++ b/src/EFCoreSecondLevelCacheInterceptor/EFCoreSecondLevelCacheInterceptor.csproj
@@ -67,40 +67,40 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.10" />
-    <PackageReference Include="CacheManager.Core" Version="1.2.0" />
-    <PackageReference Include="EasyCaching.Core" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,4)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1,4)" />
+    <PackageReference Include="CacheManager.Core" Version="[1.2,2)" />
+    <PackageReference Include="EasyCaching.Core" Version="[1.1,2)" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>NET4_6_1</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" ('$(TargetFramework)' == 'netstandard2.0')">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.10" />
-    <PackageReference Include="CacheManager.Core" Version="1.2.0" />
-    <PackageReference Include="EasyCaching.Core" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,4)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1,4)" />
+    <PackageReference Include="CacheManager.Core" Version="[1.2,2)" />
+    <PackageReference Include="EasyCaching.Core" Version="[1.1,2)" />
   </ItemGroup>
   <PropertyGroup Condition="('$(TargetFramework)' == 'netstandard2.0')">
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1')">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.10" />
-    <PackageReference Include="CacheManager.Core" Version="1.2.0" />
-    <PackageReference Include="EasyCaching.Core" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1,4)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1,4)" />
+    <PackageReference Include="CacheManager.Core" Version="[1.2,2)" />
+    <PackageReference Include="EasyCaching.Core" Version="[1.1,2)" />
   </ItemGroup>
   <PropertyGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1')">
     <DefineConstants>NETCORE3_1</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="('$(TargetFramework)' == 'net5.0') or  ('$(TargetFramework)' == 'netstandard2.1')">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.1" />
-    <PackageReference Include="CacheManager.Core" Version="1.2.0" />
-    <PackageReference Include="EasyCaching.Core" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5,)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[5,)" />
+    <PackageReference Include="CacheManager.Core" Version="[1.2,2)" />
+    <PackageReference Include="EasyCaching.Core" Version="[1.1,2)" />
   </ItemGroup>
   <PropertyGroup Condition="('$(TargetFramework)' == 'net5.0') or  ('$(TargetFramework)' == 'netstandard2.1')">
     <DefineConstants>NET5_0</DefineConstants>


### PR DESCRIPTION
Hi,

I had an issue that prevented me to upgrade my application to EF Core 3.1.11 and in the package references I noticed that EFCoreSecondLevelCacheInterceptor was using version 3.1.10. 
That is why changed the Versions of referenced assemblies to a [version range](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges), so they are more free.

Regards,

Jochen