### PR TITLE
MessagePack TimeSpanFormatter Serialize Type Error： Unable to cast object of type 'System.UInt64' to type 'System.Int64'

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor/EFTableRowsDataReader.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/EFTableRowsDataReader.cs
@@ -521,7 +521,7 @@ public class EFTableRowsDataReader : DbDataReader
 
         if (expectedValueType == TimeSpanType && IsNumber(actualValueType))
         {
-            return (T)(object)new TimeSpan((long)value);
+            return (T)(object)new TimeSpan((ulong)value);
         }
 
         if (IsNumber(expectedValueType) && IsNumber(actualValueType))


### PR DESCRIPTION
MessagePack TimeSpanFormatter Serialize Type Error： Unable to cast object of type 'System.UInt64' to type 'System.Int64'