### PR TITLE
Switched lock provider to a more performant library

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor/EFCoreSecondLevelCacheInterceptor.csproj
+++ b/src/EFCoreSecondLevelCacheInterceptor/EFCoreSecondLevelCacheInterceptor.csproj
@@ -62,6 +62,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+		<PackageReference Include="AsyncKeyedLock" Version="[6.3.4,)"/>
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
         <Reference Include="System"/>
@@ -70,7 +71,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1,4)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
         <DefineConstants>NET4_6_2</DefineConstants>
@@ -81,7 +81,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1,4)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'netstandard2.0')">
         <DefineConstants>NETSTANDARD2_0</DefineConstants>
@@ -92,7 +91,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1,6)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1')">
         <DefineConstants>NETCORE3_1</DefineConstants>
@@ -103,7 +101,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[5,)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'netstandard2.1')">
         <DefineConstants>NETSTANDARD2_1</DefineConstants>
@@ -114,7 +111,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[5,)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'net5.0')">
         <DefineConstants>NET5_0</DefineConstants>
@@ -125,7 +121,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[6,)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'net6.0')">
         <DefineConstants>NET6_0</DefineConstants>
@@ -136,7 +131,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[7,)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'net7.0')">
         <DefineConstants>NET7_0</DefineConstants>
@@ -148,7 +142,6 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[8.0.0,)"/>
         <PackageReference Include="CacheManager.Core" Version="[1.2,)"/>
         <PackageReference Include="EasyCaching.Core" Version="[1.9.1,)"/>
-        <PackageReference Include="NeoSmart.AsyncLock" Version="[3.2.1,)"/>
     </ItemGroup>
     <PropertyGroup Condition="('$(TargetFramework)' == 'net8.0')">
         <DefineConstants>NET8_0</DefineConstants>

--- a/src/EFCoreSecondLevelCacheInterceptor/ILockProvider.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/ILockProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AsyncKeyedLock;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,15 +8,15 @@ namespace EFCoreSecondLevelCacheInterceptor;
 /// <summary>
 ///     Reader writer locking service
 /// </summary>
-public interface ILockProvider
+public interface ILockProvider : IDisposable
 {
     /// <summary>
     ///     Tries to enter the sync lock
     /// </summary>
-    IDisposable Lock(CancellationToken cancellationToken = default);
+    AsyncNonKeyedLockReleaser Lock(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Tries to enter the async lock
     /// </summary>
-    Task<IDisposable> LockAsync(CancellationToken cancellationToken = default);
+    ValueTask<AsyncNonKeyedLockReleaser> LockAsync(CancellationToken cancellationToken = default);
 }

--- a/src/EFCoreSecondLevelCacheInterceptor/LockProvider.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/LockProvider.cs
@@ -1,25 +1,36 @@
-using System;
+﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace EFCoreSecondLevelCacheInterceptor;
 
 /// <summary>
 ///     Reader writer locking service
 /// </summary>
-public class LockProvider : ILockProvider
+public sealed class LockProvider : ILockProvider
 {
-    private readonly AsyncLock _lock = new();
+    private readonly AsyncNonKeyedLocker _lock = new();
 
     /// <summary>
     ///     Tries to enter the sync lock
     /// </summary>
-    public IDisposable Lock(CancellationToken cancellationToken = default) => _lock.Lock(cancellationToken);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public AsyncNonKeyedLockReleaser Lock(CancellationToken cancellationToken = default) => _lock.Lock(cancellationToken);
 
     /// <summary>
     ///     Tries to enter the async lock
     /// </summary>
-    public Task<IDisposable> LockAsync(CancellationToken cancellationToken = default) =>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<AsyncNonKeyedLockReleaser> LockAsync(CancellationToken cancellationToken = default) =>
         _lock.LockAsync(cancellationToken);
+
+    /// <summary>
+    ///     Disposes the lock
+    /// </summary>    
+    public void Dispose()
+    {
+        _lock.Dispose();
+    }
 }


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show `AsyncNonKeyedLocker` to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144