### PR TITLE
feat(data-reader): add support for converting `DateOnly` and `TimeOnly` types from string

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor/EFTableRowsDataReader.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/EFTableRowsDataReader.cs
@@ -579,9 +579,19 @@ public class EFTableRowsDataReader : DbDataReader
             return (T)(object)DateOnly.FromDateTime((DateTime)value);
         }
 
+        if (expectedValueType == TypeExtensions.DateOnlyType && actualValueType == TypeExtensions.StringType)
+        {
+            return (T)(object)DateOnly.Parse((string)value, CultureInfo.InvariantCulture);
+        }
+
         if (expectedValueType == TypeExtensions.TimeOnlyType && actualValueType == TypeExtensions.TimeSpanType)
         {
             return (T)(object)TimeOnly.FromTimeSpan((TimeSpan)value);
+        }
+
+        if (expectedValueType == TypeExtensions.TimeOnlyType && actualValueType == TypeExtensions.StringType)
+        {
+            return (T)(object)TimeOnly.Parse((string)value, CultureInfo.InvariantCulture);
         }
 
         if (expectedValueType == TypeExtensions.TimeOnlyType && isActualValueTypeNumber)

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.UnitTests/EFTableRowsDataReaderTests.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.UnitTests/EFTableRowsDataReaderTests.cs
@@ -1567,7 +1567,7 @@ public class EFTableRowsDataReaderTests
     }
 
     [Fact]
-    public void GetFieldValue__ShouldReturnExpectedDateTimeOffsetValueFromString()
+    public void GetFieldValue_ShouldReturnExpectedDateOnlyValueFromString()
     {
         // Arrange
         var values = new List<object> { DateOnly.MaxValue.ToString(CultureInfo.InvariantCulture) };
@@ -1580,15 +1580,42 @@ public class EFTableRowsDataReaderTests
                 { 0, new EFTableColumnInfo { DbTypeName = nameof(String), Ordinal = 0 } }
             }
         };
+
         var dataReader = new EFTableRowsDataReader(tableRows);
 
         dataReader.Read();
 
         // Act
-        void Act() => dataReader.GetFieldValue<DateOnly>(0);
+        var actual = dataReader.GetFieldValue<DateOnly>(0);
 
         // Assert
-        Assert.Throws<InvalidCastException>(Act);
+        Assert.Equal(DateOnly.MaxValue, actual);
+    }
+
+    [Fact]
+    public void GetFieldValue_ShouldNotThrowInvalidCastExceptionWhenValueConversionFromStringToDateOnly()
+    {
+        // Arrange
+        var values = new List<object> { DateOnly.MaxValue.ToString(CultureInfo.InvariantCulture) };
+        var tableRow = new EFTableRow(values);
+        var tableRows = new EFTableRows
+        {
+            Rows = new List<EFTableRow> { tableRow },
+            ColumnsInfo = new Dictionary<int, EFTableColumnInfo>
+            {
+                { 0, new EFTableColumnInfo { DbTypeName = nameof(String), Ordinal = 0 } }
+            }
+        };
+
+        var dataReader = new EFTableRowsDataReader(tableRows);
+
+        dataReader.Read();
+
+        // Act
+        var exception = Record.Exception(() => dataReader.GetFieldValue<DateOnly>(0));
+
+        // Assert
+        Assert.Null(exception);
     }
 
     [Fact]
@@ -1645,6 +1672,32 @@ public class EFTableRowsDataReaderTests
     public void GetFieldValue_ShouldReturnExpectedTimeOnlyValueFromString()
     {
         // Arrange
+        var values = new List<object> { TimeOnly.MaxValue.ToString("O", CultureInfo.InvariantCulture) };
+        var tableRow = new EFTableRow(values);
+        var tableRows = new EFTableRows
+        {
+            Rows = new List<EFTableRow> { tableRow },
+            ColumnsInfo = new Dictionary<int, EFTableColumnInfo>
+            {
+                { 0, new EFTableColumnInfo { DbTypeName = nameof(String), Ordinal = 0 } }
+            }
+        };
+
+        var dataReader = new EFTableRowsDataReader(tableRows);
+
+        dataReader.Read();
+
+        // Act
+        var actual = dataReader.GetFieldValue<TimeOnly>(0);
+
+        // Assert
+        Assert.Equal(TimeOnly.MaxValue, actual);
+    }
+
+    [Fact]
+    public void GetFieldValue_ShouldNotThrowInvalidCastExceptionWhenValueConversionFromStringToTimeOnly()
+    {
+        // Arrange
         var values = new List<object> { TimeOnly.MaxValue.ToString(CultureInfo.InvariantCulture) };
         var tableRow = new EFTableRow(values);
         var tableRows = new EFTableRows
@@ -1652,18 +1705,19 @@ public class EFTableRowsDataReaderTests
             Rows = new List<EFTableRow> { tableRow },
             ColumnsInfo = new Dictionary<int, EFTableColumnInfo>
             {
-                { 0, new EFTableColumnInfo { DbTypeName = nameof(TimeSpan), Ordinal = 0 } }
+                { 0, new EFTableColumnInfo { DbTypeName = nameof(String), Ordinal = 0 } }
             }
         };
+
         var dataReader = new EFTableRowsDataReader(tableRows);
 
         dataReader.Read();
 
         // Act
-        void Act() => dataReader.GetFieldValue<DateOnly>(0);
+        var exception = Record.Exception(() => dataReader.GetFieldValue<TimeOnly>(0));
 
         // Assert
-        Assert.Throws<InvalidCastException>(Act);
+        Assert.Null(exception);
     }
 
     [Fact]


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the value in the database is stored as a string and the target type is `DateOnly`, this results in an exception:

```csharp
System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.DateOnly'.
   at EFCoreSecondLevelCacheInterceptor.EFTableRowsDataReader.GetFieldValue[T](Int32 ordinal) in EFTableRowsDataReader.cs:line 593
```
If the value in the database is stored as a string and the target type is `TimeOnly`, this results in an exception:

```csharp
System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.TimeOnly'.
   at EFCoreSecondLevelCacheInterceptor.EFTableRowsDataReader.GetFieldValue[T](Int32 ordinal) in EFTableRowsDataReader.cs:line 593
```

This is especially relevant for SQLite.

## What is the new behavior?

Conversion without exceptions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

In the `GetFieldValue` method of `EFTableRowsDataReader` class, there is code to convert a string to `DateTimeOffsetType`:
https://github.com/VahidN/EFCoreSecondLevelCacheInterceptor/blob/57f59089995ec238c7354cc88868a245b5e9acc9/src/EFCoreSecondLevelCacheInterceptor/EFTableRowsDataReader.cs#L528

However, there is `no` corresponding code for the `DateOnly` and `TimeOnly` types.
This issue occurs when integrating with `SQLite`.

In the original `SqliteValueReader`, there is the following code:
https://github.com/dotnet/efcore/blob/bb583a91d7269510ecb09a4466fee61bc62280d1/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs#L71

```csharp
#if NET6_0_OR_GREATER
        public virtual DateOnly GetDateOnly(int ordinal)
        {
            var sqliteType = GetSqliteType(ordinal);
            switch (sqliteType)
            {
                case SQLITE_FLOAT:
                case SQLITE_INTEGER:
                    return DateOnly.FromDateTime(FromJulianDate(GetDouble(ordinal)));

                default:
                    return DateOnly.Parse(GetString(ordinal), CultureInfo.InvariantCulture);
            }
        }

        public virtual TimeOnly GetTimeOnly(int ordinal)
            => TimeOnly.Parse(GetString(ordinal), CultureInfo.InvariantCulture);
#endif
```

These changes expand `DateOnly` and `TimeOnly` support.

Best Regards,
Dmitrii Kiselev