### PR TITLE
EFHybridCacheProvider inserted wrong initial value in cache when calling GetValue

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor.HybridCache/EFHybridCacheProvider.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor.HybridCache/EFHybridCacheProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -63,10 +63,7 @@ public class EFHybridCacheProvider(
         ArgumentNullException.ThrowIfNull(cacheKey);
 
         return hybridCache.GetOrCreateAsync<EFCachedData?>(cacheKey.KeyHash, factory
-                => ValueTask.FromResult<EFCachedData?>(new EFCachedData
-                {
-                    IsNull = true
-                }))
+                => ValueTask.FromResult<EFCachedData?>(null))
             .Preserve()
             .GetAwaiter()
             .GetResult();


### PR DESCRIPTION
This PR fixes the `EFHybridCacheProvider.GetValue` method. The implemented factory method for the hybrid cache inserted an `EFCacheResult` with `IsNull` set to true. This caused that interceptor thought there was already a cached version for that query and that there was never a database call done (even the first time) leading to `null` being returned all the time.
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?
The `EFHybridCacheProvider.GetValue` always returns `EFCacheResult { IsNull: true }` due to the way the factory method in the `HybridCache.GetOrCreateAsync` was implemented. That way, `EFHybridCacheProvider.InsertValue` was never called, because the interceptor thought there was already a cached value.

## What is the new behavior?
The `EFHybridCacheProvider.GetValue` initially returns `null`, forcing the database query to trigger the first time (or after cache expiration).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No