### PR TITLE
Fix closed DbDataReader issue in EFCoreSecondLevelCacheInterceptor

### DIFF
--- a/src/EFCoreSecondLevelCacheInterceptor/DbCommandInterceptorProcessor.cs
+++ b/src/EFCoreSecondLevelCacheInterceptor/DbCommandInterceptorProcessor.cs
@@ -60,6 +60,7 @@ public class DbCommandInterceptorProcessor : IDbCommandInterceptorProcessor
         }
 
         EFCacheKey? efCacheKey = null;
+        EFTableRows? tableRows = null;
 
         try
         {
@@ -133,8 +134,6 @@ public class DbCommandInterceptorProcessor : IDbCommandInterceptorProcessor
 
             if (result is DbDataReader dataReader)
             {
-                EFTableRows tableRows;
-
                 using (var dbReaderLoader = new EFDataReaderLoader(dataReader))
                 {
                     tableRows = dbReaderLoader.Load();
@@ -201,6 +200,14 @@ public class DbCommandInterceptorProcessor : IDbCommandInterceptorProcessor
 
                 _logger.NotifyCacheableEvent(CacheableLogEventId.CachingError, ex.ToString(), command.CommandText,
                     efCacheKey);
+            }
+
+            if(tableRows != null){
+                return (T)(object)new EFTableRowsDataReader(tableRows
+#if NET10_0 || NET9_0 || NET8_0 || NET7_0 || NET6_0 || NET5_0
+                    , _cacheSettings
+#endif
+                );
             }
 
             return result;


### PR DESCRIPTION
Bugfix

**What is the current behavior?**

When a query result is a DbDataReader, the interceptor loads all rows into EFTableRows for caching purposes using EFDataReaderLoader.
However, after the reader is fully consumed (and potentially closed), the original DbDataReader instance is still returned from ProcessExecutedCommands.

This can lead to runtime exceptions such as:

InvalidOperationException: The reader is closed

when EF Core or downstream consumers attempt to read from the returned reader.

**What is the new behavior?**

If the result is a DbDataReader and its rows have been successfully loaded into EFTableRows, the interceptor now returns an EFTableRowsDataReader instead of the original reader.

This ensures that:

A valid, open reader is always returned

The returned reader is independent of the lifecycle of the original DbDataReader

The "The reader is closed" exception no longer occurs in this scenario

If no table rows are loaded, the original result is returned unchanged.

Does this PR introduce a breaking change? - No

Other information

This change fixes an edge case where consuming a DbDataReader for caching purposes invalidated the original reader instance.
The fix is backward-compatible and only affects scenarios where query results are intercepted and cached.