### PR TITLE
fix: Resolve context disposed exception in MsSqlContextFactory and AspNetCoreSample

### DIFF
--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/Migrations/20260407122742_V_04_2026_1327.Designer.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/Migrations/20260407122742_V_04_2026_1327.Designer.cs
@@ -4,6 +4,7 @@ using EFCoreSecondLevelCacheInterceptor.Tests.DataLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EFCoreSecondLevelCacheInterceptor.Tests.DataLayer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407122742_V_04_2026_1327")]
+    partial class V_04_2026_1327
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/Migrations/20260407122742_V_04_2026_1327.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/Migrations/20260407122742_V_04_2026_1327.cs
@@ -1,0 +1,302 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EFCoreSecondLevelCacheInterceptor.Tests.DataLayer.Migrations
+{
+    /// <inheritdoc />
+    public partial class V_04_2026_1327 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "ImageData",
+                table: "Users",
+                type: "varbinary(max)",
+                nullable: false,
+                defaultValue: new byte[0],
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "ByteArrayValue",
+                table: "Users",
+                type: "varbinary(max)",
+                nullable: false,
+                defaultValue: new byte[0],
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Tags",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                table: "Products",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Posts",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Revision",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Patch",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Minor",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Major",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Revision",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Patch",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Minor",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Major",
+                table: "EngineVersions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Url",
+                table: "Blogs",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SiteUrl",
+                table: "BlogData",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "ImageData",
+                value: new byte[0]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "ImageData",
+                table: "Users",
+                type: "varbinary(max)",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)");
+
+            migrationBuilder.AlterColumn<byte[]>(
+                name: "ByteArrayValue",
+                table: "Users",
+                type: "varbinary(max)",
+                nullable: true,
+                oldClrType: typeof(byte[]),
+                oldType: "varbinary(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Tags",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                table: "Products",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Posts",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Revision",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Patch",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Minor",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Retail_Major",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Revision",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Patch",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Minor",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Commercial_Major",
+                table: "EngineVersions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Url",
+                table: "Blogs",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SiteUrl",
+                table: "BlogData",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "ImageData",
+                value: null);
+        }
+    }
+}

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/MsSqlContextFactory.cs
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/MsSqlContextFactory.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore.Design;
+﻿using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -40,7 +40,7 @@ public class MsSqlContextFactory : IDesignTimeDbContextFactory<ApplicationDbCont
 
         services.AddConfiguredMsSqlDbContext(connectionString);
 
-        using var buildServiceProvider = services.BuildServiceProvider();
+        var buildServiceProvider = services.BuildServiceProvider();
 
         return buildServiceProvider.GetRequiredService<ApplicationDbContext>();
     }

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/_01-add_migrations.cmd
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/_01-add_migrations.cmd
@@ -1,6 +1,6 @@
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c_%%a_%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME: =0%") do (set mytime=%%a%%b)
-dotnet tool update --global dotnet-ef --version 9.0.0
+dotnet tool update --global dotnet-ef --version 10.0.0
 dotnet build
 dotnet ef migrations --startup-project ../EFCoreSecondLevelCacheInterceptor.AspNetCoreSample/ add V%mydate%_%mytime% --context ApplicationDbContext
 pause

--- a/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/_02-update_db.cmd
+++ b/src/Tests/EFCoreSecondLevelCacheInterceptor.Tests.DataLayer/_02-update_db.cmd
@@ -1,4 +1,4 @@
-dotnet tool update --global dotnet-ef --version 9.0.0
+dotnet tool update --global dotnet-ef --version 10.0.0
 dotnet build
 dotnet ef --startup-project ../EFCoreSecondLevelCacheInterceptor.AspNetCoreSample/ database update --context ApplicationDbContext
 pause


### PR DESCRIPTION
Hi, I'm looking at adding a custom provider but discovered an issue with the sample/example site while trying to build the project locally. 

I believe when the project was updated to support .Net 10 various `using`s were added that may have broken the migration scripts. This PR removes the offending `using` from MSSqlContextFactory and regenerates the migrations so AspNetCoreSample can be run up.

# PR Checklist

  - [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
  - [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] Docs have been added / updated (for bug fixes / features)

  ## PR Type

  - [x] Bugfix

  ## What is the current behavior?

  `MsSqlContextFactory` implements `IDesignTimeDbContextFactory<ApplicationDbContext>`, which
  EF Core's design-time tooling (e.g. `dotnet ef migrations add`, `dotnet ef database update`)
  uses to create a `DbContext` instance when no application entry point is available.

  The factory builds a full `ServiceCollection` — including `AddEFSecondLevelCache` and
  `AddConfiguredMsSqlDbContext` — then resolves `ApplicationDbContext` from it. Because
  `ApplicationDbContext` is registered with a scoped lifetime, `using var buildServiceProvider`
  disposes the `ServiceProvider` (and all its scoped services) before the returned context can
  be used. This causes an `ObjectDisposedException` when running EF design-time commands.

  Closes #

  ## What is the new behavior?

  Removed `using` from `var buildServiceProvider = services.BuildServiceProvider()` so the
  `ServiceProvider` is not eagerly disposed before the `ApplicationDbContext` is returned to
  the EF tooling. The SQL Server migrations are also regenerated as a result of the fix
  allowing the tooling to run successfully.

  ## Does this PR introduce a breaking change?

  - [ ] Yes
  - [x] No

  ## Other information

  N/A